### PR TITLE
Add `scipy` as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 matplotlib
+scipy
 tqdm


### PR DESCRIPTION
Although removed in previous commits, `scipy` is still a requirement as its used in [priors.py](smcpy/priors.py) viz. 

https://github.com/nasa/SMCPy/blob/b1ae16a74680fcbb133cc6bbf4c5e87f2bb5026c/smcpy/priors.py#L3

This PR simply aims to fix that by adding `scipy` in the `requirements.txt` file
