### PR TITLE
Fix example and image link in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,13 @@ divided by mass, and g, the gravitational constant on an unknown planet. These
 estimates are in the form of weighted particles and can be visualized by
 plotting the pairwise weights as shown below. The mean of each parameter is
 marked by the dashed red line. The true values for this example were K = 1.67
-and g = 4.62. More details can be found in the spring mass example
-(smcpy/examples/spring_mass/).
+and g = 4.62. More details can be found in the [spring mass example](examples/spring_mass/).
 
 To run this model in parallel using MPI, the MCMC kernel just needs to be built
 with the ParallelMCMC class in place of VectorMCMC. More details can be found
-in the MPI example (smcpy/examples/mpi_example/).
+in the [MPI example](examples/mpi_example/).
 
-![Pairwise](https://github.com/nasa/SMCPy/blob/main/examples/spring_mass/pairwise.png)
+![Pairwise](examples/spring_mass/spring_mass_smc_example.png
 
 Tests
 -----

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To run this model in parallel using MPI, the MCMC kernel just needs to be built
 with the ParallelMCMC class in place of VectorMCMC. More details can be found
 in the [MPI example](examples/mpi_example/).
 
-![Pairwise](examples/spring_mass/spring_mass_smc_example.png
+![Pairwise](examples/spring_mass/spring_mass_smc_example.png)
 
 Tests
 -----


### PR DESCRIPTION
Although links to the the "spring mass" and "MPI" example were present in the README, they weren't hyperlinked in the correct way. This PR aims to :-

- Fix example links by actually linking using the `[]()` syntax.
- Fix image link to point to the current example image in the `spring_mass` example folder. viz `spring_mass_smc_example.png`.